### PR TITLE
Fix incompatible JS with ECMAScript_2020

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/commerce/ui/components/productdata/clientlibs/js/productdata.js
+++ b/ui.apps/src/main/content/jcr_root/apps/commerce/ui/components/productdata/clientlibs/js/productdata.js
@@ -25,7 +25,7 @@
             let skuField = e.target;
             const roleField = skuField.nextElementSibling;
             let orderField = roleField;
-            if (orderField?.classList.contains("commerce-product-order")) {
+            if (orderField && orderField.classList.contains("commerce-product-order")) {
                 orderField.value = orderField.value || -1;
             }
 


### PR DESCRIPTION
Fix error:
`
2025/11/20 13:49:36.187] [SEVERE] com.adobe.granite.clientlibs.compiler.gcc.impl.GCCLogErrorManager - apps/commerce/ui/components/productdata/clientlibs.min.js:28:16: ERROR - [JSC_LANGUAGE_FEATURE] This language feature is only supported for ECMASCRIPT_2020 mode or better: Optional chaining.
            if (orderField?.classList.contains("commerce-product-order")) {
                ^

[2025/11/20 13:49:36.187] [WARNING] com.adobe.granite.clientlibs.compiler.gcc.impl.GCCLogErrorManager - 1 error(s), 0 warning(s)
`